### PR TITLE
fix: Resolve remaining CI failures (pytest imports and pnpm version)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -84,10 +84,8 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-        with:
-          version: 9
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.0.0
 
       - name: Install Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
+pythonpath = .
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*


### PR DESCRIPTION
## Summary
This PR fixes the remaining CI failures discovered after merging PR #25.

## Changes
1. **Pytest Import Fix**: Added `pythonpath = .` to `pytest.ini` to resolve `ModuleNotFoundError` for `hooks.pre_gen` module
2. **pnpm Version Fix**: Removed explicit pnpm version from `security-scan.yml` to avoid conflict with `packageManager` field in `package.json`

## Background
These issues were unrelated to the Copier hook issue fixed in PR #25. They were separated into this PR as per plan:
- PR #25 (merged) ✅: Fixed core Copier hook configuration
- This PR: Addresses remaining unrelated CI failures

## Technical Details

### Pytest Import Error
The pytest tests were failing with `ModuleNotFoundError: No module named 'hooks'` because pytest couldn't find the hooks module. Adding `pythonpath = .` to pytest.ini adds the project root to the Python path.

**Validation**: ✅ `uv run pytest tests/unit/test_pre_gen_normalize.py` now passes (2/2 tests)

### pnpm Version Mismatch
The Security Validation Suite workflow was failing with:
```
##[error]Error: Multiple versions of pnpm specified: Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

This occurred because:
- `package.json` has `"packageManager": "pnpm@9.0.0"`
- `security-scan.yml` also specified `version: 9` in pnpm/action-setup

When using corepack (which the workflow enables), it automatically uses the version from `packageManager` field. Specifying it again in the workflow caused a conflict.

**Fix**: Removed the explicit `version: 9` from security-scan.yml to let corepack handle version via package.json

## Expected Outcome
- ✅ Pytest tests passing
- ✅ Security Validation Suite using correct pnpm version
- ✅ Green CI badge!

## Related
- Continues work from PR #25
- Addresses final CI failures blocking green status

## Summary by Sourcery

Resolve CI failures by fixing pytest imports and removing explicit pnpm version in security scan workflow

Bug Fixes:
- Add project root to PYTHONPATH in pytest.ini to resolve ModuleNotFoundError for hooks.pre_gen
- Remove explicit pnpm version setting in security-scan.yml to avoid version mismatch with package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI security scan to use the official pnpm setup action for more reliable and maintainable builds. No impact on runtime behavior or user-facing features.
* **Tests**
  * Adjusted test configuration to include the project root in the Python path, improving test discovery and import reliability. This change affects only the testing environment and does not alter application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->